### PR TITLE
Properly Format &'s

### DIFF
--- a/Dataset_Maker.ipynb
+++ b/Dataset_Maker.ipynb
@@ -133,6 +133,7 @@
         "           .replace(\"(\", \"%28\")\\\n",
         "           .replace(\")\", \"%29\")\\\n",
         "           .replace(\":\", \"%3a\")\\\n",
+        "           .replace(\"&\", \"%26\")\\\n",
         "          \n",
         "url = \"https://gelbooru.com/index.php?page=dapi&json=1&s=post&q=index&limit=100&tags={}\".format(tags)\n",
         "user_agent = \"Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/93.0.4577.83 Safari/537.36\"\n",


### PR DESCRIPTION
I was having issues trying to scrape based on a tag with an & in it, and i noticed that & translates into %26 in the url. There was nothing replacing it in the code, so I added a line to do so and it now works. Opening a whole issue for something so minor seemed like a waste of your time, so I did this instead