### PR TITLE
Exclude image files case-insensitively in dataset clean cell

### DIFF
--- a/Dataset_Maker.ipynb
+++ b/Dataset_Maker.ipynb
@@ -755,7 +755,7 @@
         "#@markdown ### 🚮 Clean folder\n",
         "#@markdown Careful! Deletes all non-image files in the project folder.\n",
         "\n",
-        "!find {images_folder} -type f ! \\( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \\) -delete\n"
+        "!find {images_folder} -type f ! \\( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' \\) -delete\n"
       ]
     }
   ],


### PR DESCRIPTION
The find command matches case-sensitive with the -name parameter and case-insensitive with -iname.

It's a bit annoying, because for example images on iOS have their extensions capitalized, resulting in them being deleted by the command.