### PR TITLE
[fix] Lora_Trainer_XL resolution slider not showing

### DIFF
--- a/Lora_Trainer_XL.ipynb
+++ b/Lora_Trainer_XL.ipynb
@@ -157,7 +157,7 @@
         "model_url = model_url.strip()\n",
         "\n",
         "#@markdown ### ▶️ Processing\n",
-        "resolution = 1024 #param {type:\"slider\", min:768, max:1536, step:128}\n",
+        "resolution = 1024 #@param {type:\"slider\", min:768, max:1536, step:128}\n",
         "caption_extension = \".txt\" #@param [\".txt\", \".caption\"]\n",
         "#@markdown Shuffling anime tags in place improves learning and prompting. An activation tag goes at the start of every text file and will not be shuffled.<p>\n",
         "shuffle_tags = True #@param {type:\"boolean\"}\n",


### PR DESCRIPTION
There was a missing symbol, so the resolution slider was not showing. A quick and easy fix!